### PR TITLE
Editorial updates on OIDC Authentication

### DIFF
--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -139,7 +139,7 @@ _This section is non-normative_
 In the Solid ecosystem, an IdP may be controlled, supplied and used by any
 entity, and may exist for any length of time.
 
-This specification makes use of OAuth and OIDC best practices and assumes the
+This specification makes use of OAuth and OIDC best practices and adopts the
 [Authorization](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps)
 Code Flow with PKCE, as per OIDC definition. It is also assumed that there is
 no preexisting trust relationship with the IdP. This means dynamic, and static
@@ -191,8 +191,8 @@ IdP:
 1. A DPoP-bound Access Token
 2. An OIDC ID Token
 
-These tokens require additional and/or modified claims for them to be compliant with the
-authorization flow laid out in this document.
+These tokens require new or modified claims for them to be compliant with the
+authorization flow as outlined in [Basic Flow](#basic-flow).
 
 ## DPoP-bound Access Token
 

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -194,7 +194,7 @@ IdP:
 These tokens require additional and/or modified claims for them to be compliant with the
 authorization flow laid out in this document.
 
-## Access Token
+## DPoP-bound Access Token
 
 The client MUST send the IdP a DPoP proof that is valid according to the
 [DPoP Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04).
@@ -207,18 +207,18 @@ An example Access Token:
 
 ```js
 {
-    "sub": "https://janedoe.com/web#id", // Web ID of User
+    "sub": "https://janedoe.com/web#id", // WebID of User
     "iss": "https://idp.example.com",
     "aud": "solid",
     "iat": 1541493724,
     "exp": 1573029723, // Identity credential expiration (separate from the ID token expiration)
     "cnf":{
       "jkt":"0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I" // DPoP public key confirmation claim
-    },
+    }
 }
 ```
 
-## ID Token
+## OICD ID Token
 
 The subject (`sub`) claim in the returning ID Token MUST be set to the user's WebID.
 
@@ -231,7 +231,7 @@ Example:
     "aud": "https://client.example.com",
     "nonce": "n-0S6_WzA2Mj",
     "exp": 1311281970,
-    "iat": 1311280970,
+    "iat": 1311280970
 }
 ```
 
@@ -242,39 +242,41 @@ access resources using a traditional `Bearer` tokens.
 
 ## DPoP Validation
 
-If a `cnf` claim is present in the Access Token, then it must a DPoP Proof must be present and
-validated using the methods outlined in the
-[DPoP Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04#section-4.2).
+If a `cnf` claim is present in the DPoP-bound Access Token, then it must a DPoP
+Proof must be present and validated using the methods outlined in the [DPoP
+Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04#section-4.2).
 
 As defined, this includes ensuring that the DPoP Proof has not expired, and both the URL and the
 HTTP method match that of the requested resource. If any of these checks fail, the RS MUST deny the
 resource request.
 
-## Validating the Access Token
+## Validating the DPoP-bound Access Token
 
-The public key in the fingerprint of the Access Token MUST be checked against the DPoP fingerprint
-to ensure a match, as outlined in the
-[DPoP Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04#section-6).
+The public key in the fingerprint of the DPoP-bound Access Token MUST be
+checked against the DPoP fingerprint to ensure a match, as outlined in the
+[DPoP
+Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04#section-6).
 
-### WebID
+### WebID Claim and Check
 
-The `sub` claim of the Access Token MUST be a WebID. This needs to be dereferenced and checked
-against the `iss` claim in the Access Token. If the `iss` claim is different from the domain of the
-WebID, then the RS MUST check the WebID document for a `solid:oidcIssuer` property to check the
-token issuer is listed. This prevents a malicious identity provider from issuing valid Access Tokens
-for arbitrary WebIDs.
+The `sub` claim of the DPoP-bound Access Token MUST be a WebID. This needs to
+be dereferenced and checked against the `iss` claim in the DPoP-bound Access
+Token. If the `iss` claim is different from the domain of the WebID, then the
+RS MUST check the WebID document for a `solid:oidcIssuer` property to check
+the token issuer is listed. This prevents a malicious identity provider from
+issuing valid DPoP-bound Access Tokens for arbitrary WebIDs.
 
 # Security Considerations
 
 _This section is non-normative_
 
-As this specification builds upon existing web standards, security considerations from OAuth, OIDC,
+As this specification builds upon existing Web standards, security considerations from OAuth, OIDC,
 PKCE, and the DPoP specifications may also apply unless otherwise indicated. The following
 considerations should be reviewed by implementors and system/s architects of this specification.
 
 ## TLS Requirements
 
-All TLS requirements oulined in
+All TLS requirements outlined in
 [OIDC Section 16.17](https://openid.net/specs/openid-connect-core-1_0.html#Security) apply to this
 specification.
 
@@ -297,19 +299,20 @@ _This section is non-normative_
 Clients are ephemeral, client registration is optional, and most clients cannot keep secrets. These,
 among other factors, are what makes client trust challenging.
 
-# Privacy considerations
+# Privacy Considerations
 
 _This section is non-normative_
 
-## Access Token Reuse
+## DPoP-bound Access Token Reuse
 
-With JWTs being extendable by design, there is potential for a privacy breach if Access Tokens get
-reused across multiple resource servers. It is not unimaginable that a custom claim is added to the
-Access Token on instantiation. This addition may unintentionally give other resource servers
-consuming the Access Token information about the user that they may not wish to share outside of the
-intended RS.
+With JWTs being extendable by design, there is potential for a privacy breach
+if DPoP-bound Access Tokens get reused across multiple resource servers. It is
+not unimaginable that a custom claim is added to the DPoP-bound Access Token
+on instantiation. This addition may unintentionally give other resource
+servers consuming the DPoP-bound Access Token information about the user that
+they may not wish to share outside of the intended RS.
 
-# Acknowledgments
+# Acknowledgements
 
 > TODO:
 

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -325,7 +325,7 @@ on instantiation. This addition may unintentionally give other resource
 servers consuming the DPoP-bound Access Token information about the user that
 they may not wish to share outside of the intended RS.
 
-# Acknowledgements
+# Acknowledgments
 
 > TODO:
 

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -42,7 +42,7 @@ Data](https://www.w3.org/DesignIssues/LinkedData) design principles.
 
 In order to allow entities to authenticate in the [Solid
 ecosystem](https://solid.github.io/specification/), this specification
-combines with [OAuth 2.0](https://tools.ietf.org/html/rfc6749) and [OpenID
+combines [OAuth 2.0](https://tools.ietf.org/html/rfc6749) and [OpenID
 Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html).
 
 In a changing world where privacy and control of digital identities are

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -72,19 +72,20 @@ it is likely that authorization requirements will necessitate it.
 
 _This section is non-normative_
 
-This specification uses the terms "access token", "authorization server", "resource server" (RS),
-"authorization endpoint", "token endpoint", "grant type", "access token reques", "access token
-response", and "client" defined by The OAuth 2.0 Authorization Framework
+This specification uses the terms "access token", "authorization server",
+"resource server" (RS), "authorization endpoint", "token endpoint", "grant
+type", "access token request", "access token response", and "client" defined
+by The OAuth 2.0 Authorization Framework
 \[[RFC6749](https://tools.ietf.org/html/rfc6749)\].
 
-Throughout this specification, we will use the term Identity Provider (IdP) in line with the
-terminology used in the
-[Open ID Connect Core 1.0 specification](https://openid.net/specs/openid-connect-core-1_0.html)
-(OIDC). It should be noted that
-[The OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749) (OAuth) refers to this
-same entity as an Authorization Server.
+This specification uses the notion of Identity Provider (IdP) from the [Open
+ID Connect Core 1.0
+specification](https://openid.net/specs/openid-connect-core-1_0.html) (OIDC).
+It should be noted that [The OAuth 2.0 Authorization
+Framework](https://tools.ietf.org/html/rfc6749) (OAuth) refers to this same
+entity as an Authorization Server.
 
-This specification also defines the following terms:
+This specification also uses the following terms:
 
 **WebID** _as defined in the
 [WebID 1.0 Editors Draft](https://dvcs.w3.org/hg/WebID/raw-file/tip/spec/identity-respec.html)_

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -41,10 +41,10 @@ extensible and modular decentralized applications based on [Linked
 Data](https://www.w3.org/DesignIssues/LinkedData) design principles.
 
 In order to allow entities to authenticate in the [Solid
-ecosystem](https://solid.github.io/specification/), this specification
-interoperably combines functionality based on widely implemented standards
-such as [OAuth 2.0](https://tools.ietf.org/html/rfc6749) and [OpenID Connect
-Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html).
+ecosystem](https://solid.github.io/specification/), this specification is
+interoperably combined with [OAuth 2.0](https://tools.ietf.org/html/rfc6749)
+and [OpenID Connect Core
+1.0](https://openid.net/specs/openid-connect-core-1_0.html).
 
 In a changing world where privacy and control of digital identities are
 becoming more pressing concerns, this specification addresses additional

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -259,12 +259,15 @@ Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04#section-6).
 
 ### WebID Claim and Check
 
+In order to prevent a malicious identity provider from issuing valid
+DPoP-bound Access Tokens for arbitrary WebIDs, the following check is
+required:
+
 The `sub` claim of the DPoP-bound Access Token MUST be a WebID. This needs to
 be dereferenced and checked against the `iss` claim in the DPoP-bound Access
 Token. If the `iss` claim is different from the domain of the WebID, then the
 RS MUST check the WebID document for a `solid:oidcIssuer` property to check
-the token issuer is listed. This prevents a malicious identity provider from
-issuing valid DPoP-bound Access Tokens for arbitrary WebIDs.
+the token issuer is listed.
 
 # Security Considerations
 

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -131,13 +131,14 @@ when, they appear in all capitals, as shown here.
 
 _This section is non-normative_
 
-In a decentralized ecosystem, such as Solid, an IdP may be a preexisting IdP or vendor, or at the
-other end of the spectrum, a user-controlled IdP.
+In the Solid ecosystem, an IdP may be controlled, supplied and used by any
+entity, and may exist for any length of time.
 
-Therefore, this specification makes extensive use of OAuth and OIDC best practices and assumes the
-[Authorization](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps) Code Flow with
-PKCE, as per OIDC definition. It is also assumed that there is no preexisting trust relationship
-with the IdP. This means dynamic, and static client registration is entirely optional.
+This specification makes use of OAuth and OIDC best practices and assumes the
+[Authorization](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps)
+Code Flow with PKCE, as per OIDC definition. It is also assumed that there is
+no preexisting trust relationship with the IdP. This means dynamic, and static
+client registration is entirely optional.
 
 ## WebIDs
 

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -41,10 +41,9 @@ extensible and modular decentralized applications based on [Linked
 Data](https://www.w3.org/DesignIssues/LinkedData) design principles.
 
 In order to allow entities to authenticate in the [Solid
-ecosystem](https://solid.github.io/specification/), this specification is
-interoperably combined with [OAuth 2.0](https://tools.ietf.org/html/rfc6749)
-and [OpenID Connect Core
-1.0](https://openid.net/specs/openid-connect-core-1_0.html).
+ecosystem](https://solid.github.io/specification/), this specification
+combines with [OAuth 2.0](https://tools.ietf.org/html/rfc6749) and [OpenID
+Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html).
 
 In a changing world where privacy and control of digital identities are
 becoming more pressing concerns, this specification addresses additional

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -34,27 +34,32 @@ of this specification. Alternatively, you can send comments to our mailing list.
 
 _This section is non-normative_
 
-The [Solid project](https://solidproject.org/) aims to change the way web applications work today to
-improve privacy and user control of personal data by utilizing current standards, protocols, and
-tools, to facilitate building extensible and modular decentralized applications based on
-[Linked Data](https://www.w3.org/standards/semanticweb/data) principles.
+The [Solid project](https://solidproject.org/) aims to change the way Web
+applications work today to improve privacy and user control of personal data
+by using current standards, protocols, and tools, to facilitate building
+extensible and modular decentralized applications based on [Linked
+Data](https://www.w3.org/DesignIssues/LinkedData) design principles.
 
-This specification is written for Authorization and Resource Server owners intending to implement
-Solid-OIDC. It is also useful to Solid application developers charged with implementing a Solid-OIDC
-client.
+In order to allow entities to authenticate in the [Solid
+ecosystem](https://solid.github.io/specification/), this specification
+interoperably combines functionality based on widely implemented standards
+such as [OAuth 2.0](https://tools.ietf.org/html/rfc6749) and [OpenID Connect
+Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html).
 
-The [OAuth 2.0](https://tools.ietf.org/html/rfc6749) and
-[OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) web standards were
-published in October 2012, and November 2014, respectively. Since publication, they have increased
-with a marked pace and have claimed wide adoption with extensive _'real-world'_ data and experience.
-The strengths of the protocols are now clear, however, in a changing eco-system where privacy and
-control of digital identities are becoming more pressing concerns, it is also clear that additional
-functionality is required.
-
-The additional functionality is aimed at addressing:
+In a changing world where privacy and control of digital identities are
+becoming more pressing concerns, this specification addresses additional
+functionality:
 
 1. Ephemeral clients as a common use case.
 2. Resource servers with no existing trust relationship with identity providers.
+
+This specification is for:
+
+* Authorization and Resource Server owners who want to enable applications to
+obtain access to an HTTP service;
+
+* Application developers who want to implement a client to obtain access to an
+HTTP service.
 
 ## Out of Scope
 

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -273,9 +273,19 @@ the token issuer is listed.
 
 _This section is non-normative_
 
-As this specification builds upon existing Web standards, security considerations from OAuth, OIDC,
-PKCE, and the DPoP specifications may also apply unless otherwise indicated. The following
-considerations should be reviewed by implementors and system/s architects of this specification.
+As this specification builds upon existing Web standards, security
+considerations from OAuth, OIDC, PKCE, and the DPoP specifications may also
+apply unless otherwise indicated. The following considerations should be
+reviewed by implementors and system architects of this specification.
+
+Some of the normative references with this specification point to documents
+with a Living Standard or Draft status, meaning their contents can still
+change over time. It is advised to monitor these documents, as such changes
+might have security implications.
+
+In addition to above considerations, implementors should consider the Security
+Considerations in context of the [Solid
+Ecosystem](https://solid.github.io/specification/).
 
 ## TLS Requirements
 

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -242,8 +242,8 @@ access resources using a traditional `Bearer` tokens.
 
 ## DPoP Validation
 
-If a `cnf` claim is present in the DPoP-bound Access Token, then it must a DPoP
-Proof must be present and validated using the methods outlined in the [DPoP
+If a `cnf` claim is present in the DPoP-bound Access Token, then the DPoP
+Proof MUST be present and validated using the methods outlined in the [DPoP
 Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04#section-4.2).
 
 As defined, this includes ensuring that the DPoP Proof has not expired, and both the URL and the

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -218,7 +218,7 @@ An example Access Token:
 }
 ```
 
-## OICD ID Token
+## OIDC ID Token
 
 The subject (`sub`) claim in the returning ID Token MUST be set to the user's WebID.
 

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -87,8 +87,7 @@ entity as an Authorization Server.
 
 This specification also uses the following terms:
 
-**WebID** _as defined in the
-[WebID 1.0 Editors Draft](https://dvcs.w3.org/hg/WebID/raw-file/tip/spec/identity-respec.html)_
+**WebID** _as defined in [WebID 1.0](https://www.w3.org/2005/Incubator/webid/spec/identity/)_
 
 A WebID is a URI with an HTTP or HTTPS scheme which denotes an Agent (Person, Organization, Group,
 Device, etc.)
@@ -146,17 +145,19 @@ Code Flow with PKCE, as per OIDC definition. It is also assumed that there is
 no preexisting trust relationship with the IdP. This means dynamic, and static
 client registration is entirely optional.
 
-## WebIDs
+## WebID
 
 _This section is non-normative_
 
-In line with Linked Data principles, a
-[WebID](https://dvcs.w3.org/hg/WebID/raw-file/tip/spec/identity-respec.html) is a HTTP URI that,
-when dereferenced, resolves to a profile document that is structured data in an
-[RDF format](https://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/). This profile document allows
-people to link with others to grant access to identity resources as they see fit. WebIDs are an
-underpinning principle of the Solid movement and are used as the primary identifier for users and
-client applications in this specification.
+A [WebID](https://www.w3.org/2005/Incubator/webid/spec/identity/) is a HTTP
+URI denoting an agent, for example a person, organisation, or software. When a
+WebID is dereferenced, server provides a representation of the WebID Profile
+in an [RDF document](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-document)
+which uniquely describes an agent denoted by a WebID. The WebID Profile can be
+used by controlling agents to link with others to grant access to identity
+resources as they see fit. WebIDs are an underpinning component in the Solid
+ecosystem and are used as the primary identifier for users and client
+applications in this specification.
 
 # Basic Flow
 

--- a/oidc-authentication.md
+++ b/oidc-authentication.md
@@ -2,10 +2,10 @@
 
 # Abstract
 
-A key challenge on the path toward re-decentralizing user data on the Worldwide Web is the need to
-access multiple potentially untrusted resources servers securely. This document aims to address that
-challenge by building on top of current and future web standards, to allow entities to authenticate
-within a distributed ecosystem.
+A key challenge on the path toward re-decentralizing user data on the Web is
+the need to access multiple potentially untrusted resource servers securely.
+This document aims to address that challenge by building on top of current Web
+standards, to allow entities to authenticate in the Solid ecosystem.
 
 # Status of This Document
 


### PR DESCRIPTION
The PR is intended to be an editorial update. Please have a look to make sure that it doesn't introduce new errors.

In addition to the editorial update, I add a review here that can be incorporated based on feedback. If any of the points require further discussion, they should be handled as separate issues.

## Out of Scope

Re "strongly asserted identity": At this point of the spec, this is unfamiliar jargon. If it is a well-known concept defined by one of the specs, it should be cited. Otherwise, the current section doesn't help the reader (IMO).

Add: Consider mentioning social agreements such as persistence or permanence as orthogonal.

## Proof of Identity

Clarify the target: "Client registration [..] is not required" at where exactly?

## Token Instantiation

Specify client behaviour when it doesn't receive required or valid tokens.

## DPoP-bound Access Token

I'd suggest to use a URI string specific to this purpose instead of the string `solid`. If the value of `aud` is supposed to be the same in both DPoP-bound Access Token and OIDC ID Token, the examples should use the same value for clarity.

## Resource Access
Introduction refers to the notion of "Ephemeral clients" and that's kind of fine there but unclear at this point in Resource Access (or elsewhere).

## DPoP Validation

Re "the RS MUST deny the resource request", consider specifying or describing the server error.

## WebID Claim and Check

Add blurb on required concrete RDF syntax as mentioned in https://github.com/solid/authentication-panel/issues/48#issuecomment-668092738 .


