### PR TITLE
Use verifiable Identity Credential instead of Access Token

### DIFF
--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -79,10 +79,8 @@ it is likely that authorization requirements will necessitate it.
 
 *This section is non-normative*
 
-This specification uses the terms "access token", "authorization server", "resource server" (RS),
-"authorization endpoint", "token endpoint", "grant type", "access token request", "access token
-response", and "client" defined by The OAuth 2.0 Authorization Framework
-[[!RFC6749]].
+This specification uses the terms "authorization server", "resource server" (RS), "authorization endpoint",
+"token endpoint", "grant type" and "client" defined by The OAuth 2.0 Authorization Framework [[!RFC6749]].
 
 Throughout this specification, we will use the term Identity Provider (IdP) in line with the
 terminology used in the
@@ -108,7 +106,11 @@ This specification also uses the following terms:
 <dd>
     A JSON object that represents a cryptographic key. The members of the object represent properties of
     the key, including its value.
-
+<dt>*Verifiable Credential* as defined by [[!VC-DATA-MODEL]]
+<dd>
+    A verifiable credential is a tamper-evident credential that has authorship that can be cryptographically verified.
+    Verifiable credentials can be used to build verifiable presentations, which can also be cryptographically verified.
+    The claims in a credential can be about different subjects.
 <dt>*Demonstration of Proof-of-Possession at the Application Layer (DPoP)* as defined in the
 [DPoP Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04)
 <dd>
@@ -158,14 +160,15 @@ The basic authentication and authorization flow is as follows:
 
 1. The Client requests a non-public resource from the RS.
 2. The RS returns a 401 with a `WWW-Authenticate` HTTP header containing parameters that inform the
-    Client that a DPoP-bound Access Token is required.
+    Client that a Verifiable Presentation with Identity Credential is required.
 3. The Client presents its Client Identifier and the associated Secret to the IdP and requests an
     Authorization Code.
 4. If granted, the Client presents the Authorization Code and a DPoP proof, to the Token Endpoint.
-5. The Token Endpoint returns a DPoP-bound Access Token and OIDC ID Token, to the Client.
-6. The Client presents the DPoP-bound Access Token and DPoP proof, to the RS.
-7. The RS gets the public key from the IdP and uses it to validate the signature on DPoP-bound Access Token (JWS).
-8. If the DPoP proof and Access Token are valid then The RS returns the requested resource.
+5. The Token Endpoint returns an OIDC ID Token with embeded Sender Constrained Identity Credential , to the Client.
+6. The Client presents Verifiable Presentation with the Sender Constrained Identity Credential to the RS.
+7. The RS gets the public key from the IdP and uses it to validate the signature on Sender Constrained Identity Credential (JWS).
+    As well as check if Verifiable Presentation was signed with a key of the pair to which Identity Credential is bound to.
+8. If the Verifiable Presentation and Sender Constrained Identity Credentials are valid then The RS returns the requested resource.
 
 <figure id="fig-signature">
     <img src="basic-flow-diagram.png" />
@@ -232,22 +235,19 @@ registered with the IdP via either OIDC dynamic or static registration.
 
 # Token Instantiation # {#tokens}
 
-Assuming the Client ID and Secret, and the DPoP Proof are valid, the IdP MUST return two tokens to
-the Client:
+Assuming the Client ID and Secret, and the DPoP Proof are valid, the IdP MUST return to
+the Client: An OIDC Token embedding a Sender Constrained Identity Credential in `vc_id` claim.
 
-1. A DPoP-bound Access Token
-2. An OIDC ID Token
+## Sender Constrained Identity Credential ## {#identity-credential}
 
-## DPoP-bound Access Token ## {#tokens-access}
+The Sender Constrained Identity Credential MUST be a valid JWT. See [[!RFC7519]].
 
-The DPoP-bound Access Token MUST be a valid JWT. See [[!RFC7519]].
-
-When requesting an DPoP-bound Access Token, the Client MUST send the IdP a DPoP proof that is valid
+When requesting an Sender Constrained Identity Credential, the Client MUST send the IdP a DPoP proof that is valid
 according to the [DPoP Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04).
 
-The DPoP-bound Access Token MUST contain at least these claims:
+The Sender Constrained Identity Credential MUST contain at least these claims:
 
-`webid` — REQUIRED. This claim MUST be the user's WebID.
+`sub` - REQUIRED. Client's identifier.
 
 `iss` — REQUIRED. The issuer claim MUST be a valid URL of the IdP instantiating this token.
 
@@ -261,22 +261,33 @@ claim redundant, so in Solid-OIDC the `aud` claim MUST be a string with the valu
 `cnf` — For all flows that require DPoP, the confirmation claim is REQUIRED, as per
 [DPoP Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04#section-7) specification.
 
-`client_id` — REQUIRED in all flows except OIDC registration.
+`vc` - REQUERED.
+`vc.@context` - REQUIRED. constant `"https://solidproject.org/contexts/authentication"`
+`vc.type` - REQUIRED. constant `["VerifiableCredential", "IdentityCredential"]`
+`vc.credentialSubject.id` - REQUERED. Same as `sub`
+`vc.credentialSubject.canUseIdentityOf` - REQUIRED. MUST be the user's WebID.
 
 <div class="example">
-    <p>An example DPoP-bound Access Token:
+    <p>An example Sender Constrained Identity Credential:
 
     <pre>
     {
-        "webid": "https://janedoe.com/web#id",
         "iss": "https://idp.example.com",
-        "aud": "solid",
+        "sub": "https://client.example.com/web#id",
         "iat": 1541493724,
         "exp": 1573029723,
+        "aud": "solid",
         "cnf":{
-        "jkt":"0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"
+          "jkt":"0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"
         },
-        "client_id": "https://client.example.com/web#id"
+        "vc": {
+            "@context": "https://solidproject.org/contexts/authentication",
+            "type": ["VerifiableCredential", "IdentityCredential"],
+            "credentialSubject": {
+                "id": "https://client.example.com/web#id",
+                "canUseIdentityOf": "https://janedoe.com/web#id"
+            }
+        }
     }
     </pre>
 </div>
@@ -296,32 +307,51 @@ The subject (`sub`) claim MUST be the user's WebID.
             "nonce": "n-0S6_WzA2Mj",
             "exp": 1311281970,
             "iat": 1311280970,
+            "vc_id": { /* Sender Constrained Identity Credential */}
         }
     </pre>
 </div>
 
 # Resource Access # {#resource}
 
-## DPoP Proof Validation ## {#resource-dpop-validation}
+## Verifiable Presentation ## {#verifiable-presentation}
 
-A DPoP Proof that is valid according to
-[DPoP Internet-Draft, Section 4.2](https://tools.ietf.org/html/draft-fett-oauth-dpop-04#section-4.2),
-MUST be present when a DPoP-bound Access Token is used.
+Client MUST construc Verifiable Presentation following [[!VC-DATA-MODEL]]
+Verifiable Presentation JWT MUST be a valid JWS signed with the private key in the same key pair 
+as public key that Identity Credential is bound to.
 
-## Access Token Validation ## {#resource-access-validation}
+<div class="example">
+    <p>An example Verifiable Presentation including Sender Constrained Identity Credential:
 
-The DPoP-bound Access Token MUST be validated according to
-[DPoP Internet-Draft, Section 7](https://tools.ietf.org/html/draft-fett-oauth-dpop-04#section-7)
-but the RS MAY perform additional verification in order to determine whether to grant access to the
-requested resource.
+    <pre>
+    {
+        "iss": "https://client.example.com",
+        "aud": "https://rs.example/",
+        "nbf": 1541493724,
+        "iat": 1541493724,
+        "exp": 1573029723,
+        "nonce": "343s$FSFDa-",
+        "vp": {
+            "@context": "https://www.w3.org/2018/credentials/v1",
+            "type": ["VerifiablePresentation"],
+            "verifiableCredential": ["/* base64url-encoded JWT as string */"]
+        }
+    }
+    </pre>
+</div>
 
-The user's WebID in the `webid` claim MUST be dereferenced and checked against the `iss` claim in the
-Access Token. If the `iss` claim is different from the domain of the WebID, then the RS MUST check
-the WebID document for an existance of a statement matching `?webid <http://www.w3.org/ns/solid/terms#oidcIssuer> ?iss.`
-Where `?webid` and `?iss` are values of `webid` and `iss` claims respectively.
-This prevents a malicious identity provider from issuing valid Access Tokens for arbitrary WebIDs.
+## Sender Constrained Identity Credential Validation ## {#resource-access-validation}
 
-Unless RS knows IdP keys through some other means, or IdP chooses to reject tokens issued by this IdP,
+RS must verify that Verifiable Presentation JWS was signed with a private key, whose public key is
+used to bind Identity Credential.
+
+The user's WebID - the value of `canUseIdentityOf` MUST be dereferenced and checked against the `iss` claim in the
+Identity Credential. If the `iss` claim is different from the domain of the WebID, then the RS MUST check
+the WebID document for an existance of a statement matching `?canUseIdentityOf <http://www.w3.org/ns/solid/terms#oidcIssuer> ?iss.`
+Where `?canUseIdentityOf` and `?iss` are values of `canUseIdentityOf` and `iss` claims respectively.
+This prevents a malicious identity provider from issuing valid Identity Credentials for arbitrary WebIDs.
+
+Unless RS knows IdP keys through some other means, or IdP chooses to reject identity credentials issued by this IdP,
 the IdP MUST follow OpenID Connect Discovery 1.0 [[!OpenID.Discovery]] to find an IdP's signing keys (JWK).
 
 # Security Considerations # {#security}
@@ -360,14 +390,14 @@ among other factors, are what makes Client trust challenging.
 
 # Privacy Considerations # {#privacy}
 
-## Access Token Reuse ## {#privacy-token-reuse}
+## Identity Credential Reuse ## {#privacy-token-reuse}
 
 *This section is non-normative*
 
-With JWTs being extendable by design, there is potential for a privacy breach if Access Tokens get
+With JWTs being extendable by design, there is potential for a privacy breach if Identity Credentials get
 reused across multiple resource servers. It is not unimaginable that a custom claim is added to the
-Access Token on instantiation. This addition may unintentionally give other resource servers
-consuming the Access Token information about the user that they may not wish to share outside of the
+Identity Credential on instantiation. This addition may unintentionally give other resource servers
+consuming the Identity Credential information about the user that they may not wish to share outside of the
 intended RS.
 
 # Acknowledgments # {#acknowledgments}
@@ -407,6 +437,19 @@ Verborgh, Ricky White, Paul Worrall, Dmitri Zagidulin.
         "href": "https://openid.net/specs/openid-connect-discovery-1_0.html",
         "title": "OpenID Connect Discovery 1.0",
         "publisher": "The OpenID Foundation"
+    },
+    "VC-DATA-MODEL": {
+        "authors": [
+            "M. Sporny",
+            "G. Noble",
+            "D Longley",
+            "D.Burnett",
+            "B. Zundel",
+            "D. Chadwick"
+        ],
+        "href": "https://www.w3.org/TR/vc-data-model/",
+        "title": "Verifiable Credentials Data Model 1.0",
+        "publisher": "W3C"
     }
 }
 </pre>


### PR DESCRIPTION
closes #60 

This is early version just so that we can have a reference for Monday's call. As you may see at this moment it only uses DPoP with IdP to bind Identity Credential to client's public key. When making request to RS i just uses JWS of the Verifiable Presentation.

I still need to write down example where more than one credentials are being presented by the client. Otherwise it may be hard to justify proposed changes.
As additional issue I would like to discuss exchanging Verifiable Presentation for simple Access Token in similar way as proposed in https://github.com/zenomt/webid-auth-protocol#token_pop_endpoint-api-parameters