### PR TITLE
Fix GET request with fragment

### DIFF
--- a/proposals/solid-oidc-primer/index.bs
+++ b/proposals/solid-oidc-primer/index.bs
@@ -278,9 +278,9 @@ client as a public client. Doing this may cause the RS to provide less access to
 If an app WebID is provided as the client id (see note above to see other options), we must
 fetch that app WebID to confirm its validity.
 
-Request:
+For the WebID `https://decentphotos.example/webid#this` request the WebID Profile with:
 ```http
-GET https://decentphotos.example/webid#this
+GET https://decentphotos.example/webid
 ```
 
 Response:

--- a/proposals/solid-oidc-primer/index.bs
+++ b/proposals/solid-oidc-primer/index.bs
@@ -278,7 +278,7 @@ client as a public client. Doing this may cause the RS to provide less access to
 If an app WebID is provided as the client id (see note above to see other options), we must
 fetch that app WebID to confirm its validity.
 
-For the WebID `https://decentphotos.example/webid#this` request the WebID Profile with:
+For the WebID `https://decentphotos.example/webid#this`, request the WebID Profile with:
 ```http
 GET https://decentphotos.example/webid
 ```


### PR DESCRIPTION
Referencing https://github.com/solid/authentication-panel/issues/96
I could not find a place where it is stated that fragment identifiers MUST not be passed in a GET request, but I think they CANNOT be passed in an HTTP/2 request. (See [8.1.2.3 Request Pseudo header fields](https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.3))