### PR TITLE
Clarify webid claim in ID token

### DIFF
--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -270,7 +270,6 @@ claim redundant, so in Solid-OIDC the `aud` claim MUST be a string with the valu
     {
         "webid": "https://janedoe.com/web#id",
         "iss": "https://idp.example.com",
-        "sub": "janedoe",
         "aud": "solid",
         "iat": 1541493724,
         "exp": 1573029723,

--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -270,11 +270,12 @@ claim redundant, so in Solid-OIDC the `aud` claim MUST be a string with the valu
     {
         "webid": "https://janedoe.com/web#id",
         "iss": "https://idp.example.com",
+        "sub": "janedoe",
         "aud": "solid",
         "iat": 1541493724,
         "exp": 1573029723,
         "cnf":{
-        "jkt":"0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"
+          "jkt":"0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"
         },
         "client_id": "https://client.example.com/web#id"
     }
@@ -283,15 +284,16 @@ claim redundant, so in Solid-OIDC the `aud` claim MUST be a string with the valu
 
 ## OIDC ID Token ## {#tokens-id}
 
-The subject (`sub`) claim MUST be the user's WebID.
+The agent's WebID MUST be present in the ID Token as the `webid` claim.
 
 <div class="example">
     <p>An example OIDC ID Token:
 
     <pre>
         {
+            "webid": "https://janedoe.com/web#id",
             "iss": "https://idp.example.com",
-            "sub": "https://janedoe.com/web#id",
+            "sub": "janedoe",
             "aud": "https://client.example.com",
             "nonce": "n-0S6_WzA2Mj",
             "exp": 1311281970,


### PR DESCRIPTION
Resolves #89

This makes the `webid` claim more consistent across the access token and ID token.