### PR TITLE
Clarify DPoP token claims

### DIFF
--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -242,24 +242,25 @@ the Client:
 
 The DPoP-bound Access Token MUST be a valid JWT. See [[!RFC7519]].
 
-When requesting an DPoP-bound Access Token, the Client MUST send the IdP a DPoP proof that is valid
-according to the [DPoP Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04).
+When requesting a DPoP-bound Access Token, the Client MUST send the IdP a DPoP proof JWT that is valid
+according to the [DPoP Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04#section-5).
+The DPoP proof JWT is used to bind the access token to a public key. See [[!DPOP]].
 
-The DPoP-bound Access Token MUST contain at least these claims:
+The DPoP-bound Access Token payload MUST contain at least these claims:
 
-`webid` — REQUIRED. This claim MUST be the user's WebID.
+`webid` — REQUIRED. The WebID claim MUST be the user's WebID.
 
 `iss` — REQUIRED. The issuer claim MUST be a valid URL of the IdP instantiating this token.
 
 `aud` — REQUIRED. However, the DPoP token provides the full URL of the request, making the `aud`
 claim redundant, so in Solid-OIDC the `aud` claim MUST be a string with the value of `solid`.
 
-`iat` — REQUIRED. The issued-at claim is the time at which this crendential was issued.
+`iat` — REQUIRED. The issued-at claim is the time at which the DPoP-bound Access Token was issued.
 
-`exp` — REQUIRED. This credential expiration is seperate from the ID tokens expiration.
+`exp` — REQUIRED. The expiration claim is the time at which the DPoP-bound Access Token becomes invalid.
 
-`cnf` — For all flows that require DPoP, the confirmation claim is REQUIRED, as per
-[DPoP Internet-Draft](https://tools.ietf.org/html/draft-fett-oauth-dpop-04#section-7) specification.
+`cnf` — REQUIRED. The confirmation claim is used to identify the DPoP Public Key bound to the Access
+Token. See [DPoP Public Key Confirmation](https://tools.ietf.org/html/draft-fett-oauth-dpop-04#section-7).
 
 `client_id` — REQUIRED in all flows except OIDC registration.
 


### PR DESCRIPTION
Maybe a slightly more consistent way of describing the DPoP bound Access Token's required claims.