### PR TITLE
Update Editor list

### DIFF
--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -10,7 +10,7 @@ URL: https://solid.github.io/specification/solid-oidc/
 Repository: https://github.com/solid/specification
 Markup Shorthands: markdown yes
 Max ToC Depth: 2
-Editor: [Aaron Coburn](https://github.com/acoburn) ([Inrupt](https://inrupt.com))
+Editor: [Aaron Coburn](https://people.apache.org/~acoburn/webid/#i) ([Inrupt](https://inrupt.com))
 Editor: [elf Pavlik](https://elf-pavlik.hackers4peace.net/)
 Editor: [Dmitri Zagidulin](http://computingjoy.com/)
 Former Editor: [Adam Migus](https://migusgroup.com/about/) ([The Migus Group](https://migusgroup.com/))

--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -10,8 +10,11 @@ URL: https://solid.github.io/specification/solid-oidc/
 Repository: https://github.com/solid/specification
 Markup Shorthands: markdown yes
 Max ToC Depth: 2
-Editor: [Adam Migus](https://migusgroup.com/about/) ([The Migus Group](https://migusgroup.com/))
-Editor: [Ricky White](https://endlesstrax.com) ([The Migus Group](https://migusgroup.com/))
+Editor: [Aaron Coburn](https://github.com/acoburn) ([Inrupt](https://inrupt.com))
+Editor: [elf Pavlik](https://elf-pavlik.hackers4peace.net/)
+Editor: [Dmitri Zagidulin](http://computingjoy.com/)
+Former Editor: [Adam Migus](https://migusgroup.com/about/) ([The Migus Group](https://migusgroup.com/))
+Former Editor: [Ricky White](https://endlesstrax.com) ([The Migus Group](https://migusgroup.com/))
 Abstract:
   A key challenge on the path toward re-decentralizing user data on the Worldwide Web is the need to
   access multiple potentially untrusted resources servers securely. This document aims to address that

--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -10,7 +10,7 @@ URL: https://solid.github.io/specification/solid-oidc/
 Repository: https://github.com/solid/specification
 Markup Shorthands: markdown yes
 Max ToC Depth: 2
-Editor: [Aaron Coburn](https://people.apache.org/~acoburn/webid/#i) ([Inrupt](https://inrupt.com))
+Editor: [Aaron Coburn](https://people.apache.org/~acoburn/#i) ([Inrupt](https://inrupt.com))
 Editor: [elf Pavlik](https://elf-pavlik.hackers4peace.net/)
 Editor: [Dmitri Zagidulin](http://computingjoy.com/)
 Former Editor: [Adam Migus](https://migusgroup.com/about/) ([The Migus Group](https://migusgroup.com/))


### PR DESCRIPTION
As discussed at the [Jan 4, 2021 meeting](https://hackmd.io/GnZrLETNRY6L_Gn9JZPKtA), this updates the editor list for the Solid-OIDC specification document.

Ricky and Adam are now listed as "Former Editors". There was no "Author" label in bikeshed, but "Former Editor" seemed like the next best option.