### PR TITLE
added meeting notes for 2021-01-11

### DIFF
--- a/meetings/2021-01-11.md
+++ b/meetings/2021-01-11.md
@@ -1,0 +1,63 @@
+# 2021-01-11 Authentication Panel
+
+## Agenda
+
+* Using ServiceWorker [to handle case of accessing resources directly with web browser](https://github.com/solid/solid/issues/143)
+* [VC Subject-Holder Relationships](https://www.w3.org/TR/vc-data-model/#subject-holder-relationships)
+* Remaining issues in Solid-OIDC draft proposal
+* [HTTP-Sig](https://github.com/solid/authentication-panel/issues/18) and OIDC? (now [Signing HTTP Messages](https://greenbytes.de/tech/webdav/draft-ietf-httpbis-message-signatures-01.html))
+
+## Present
+
+* Aaron C
+* Justin W
+* Dmitri Z
+* Hannes
+* e Pavlik
+* Matthieu
+* Henry S
+* Sarven C
+
+
+## Minutes
+
+### issues PR
+
+ - Possible issues blocking draft submission:
+    + https://github.com/solid/authentication-panel/issues/108
+    + Review issues labeled "Solid-OIDC" https://github.com/solid/authentication-panel/issues?q=is%3Aissue+is%3Aopen+label%3ASolid-OIDC
+
+ - Move issues/PR from other solid repos to solid/solid-oidc (label #Solid-OIDC). Response.. Close
+
+ - Action for Solid-OIDC Editors?
+
+  + Determine identifier and title for the current `solid-oidc` spec
+    - https://github.com/solid/authentication-panel/issues/116
+
+### Accessing resources outside of the App
+
+Aaron explained a system used in Inrupt
+they are using in order to view resources outside of an App. (Editor: Not able to duplicate what was said here). That feature is somewhat unstable so no documentation yet.
+
+### Core-Auth
+
+Henry: What could be a core part of solid-oidc? How would the minimal auth protocol described in [HttpSig proposal sketch](
+ https://github.com/bblfish/authentication-panel/blob/master/HttpSignature.md) from last year fit? (Note HTTP-Sig is now worked on at IETF as [Signing HTTP Messages](https://greenbytes.de/tech/webdav/draft-ietf-httpbis-message-signatures-01.html))
+ 
+Dmitri:   These two specs tie in nicely with the HTTP Message Signing IETF work and would be worth looking at to see how it ties in with the above proposal:
+ + [DPOP](https://tools.ietf.org/html/draft-fett-oauth-dpop-04) used by solid-oidc
+ + [GNAP]( https://datatracker.ietf.org/doc/draft-ietf-gnap-core-protocol/) 
+ 
+Aaron: pointed in gitter to [oauth.xyz](https://oauth.xyz/) 
+
+Dmitri: the oauth.xyz is now covered by the gnap and dpop (editor: did I understand correctly?)
+
+## Actions
+
+Editors:  Determine identifier and title for the current `solid-oidc` spec
+
+Everyone: go through issues and leave notes (tags) on those that can be closed.
+
+Aaron: a sketch of how Inrupt has implemented the resource access outside of apps problem, as an issue.
+
+Henry: to read DPOP, GNAP, and see how it integrates into HTTP-Sig (Core Auth) proposal. 


### PR DESCRIPTION
It is often difficult while taking notes during a meeting to clearly
spell out what was said. Even if one should try to capture as much as
possible during the meeting, it helps for those present to go over the
notes, improve the spelling, add links dropped in the chat, and clean
it up so that people who could not make it can later follow the
dialogue more clearly, and for all at a later date to be able to
remember what was said.

So I propose that instead of directly pushing the notes to the github
repo, we instead push it as a PR like here, and ask everyone to go
over it, adding fixes if needed. Then at the beginning of each session
we can ask everyone if they are satisfied with the recording, and push
the PR.

This was how it was done in the LDP WG, but without the benefit of
Github.