### PR TITLE
mostly typo fixes

### DIFF
--- a/meetings/2021-03-15.md
+++ b/meetings/2021-03-15.md
@@ -118,15 +118,15 @@ Matthieu: Are there any specifics at the authentication protocol level for the d
 
 Dmitri: The DID community is specialising on the https://identity.foundation/did-siop/
 
-...: They're trying to centralise on DID authentication protocols. The couple of protocol that there are involve a wallet based authentication and the self issued OpenID connect.
+...: They're trying to centralise on DID authentication protocols. The couple of protocols that there are involve a wallet-based authentication and the self-issued OpenID Connect (OIDC).
 
 Sarven: Wait for maturity for requiring did:web on the Solid protocol level.
 
 Dmitri on Gitter: DIDs have been in W3C WG for about a year now, and they're going to CR either this week, or this past week.
 
-Sarven on Gitter: we are not talkin gabout DID in generall.. but did:web specifically at the moment
+Sarven on Gitter: we are not talking about DID in general... but did:web specifically at the moment
 
-Dmitri on Gitter: +1 agree with Sarven. tho obviously I'm a fan of DIDs, the solid community needs to get more experience with em etc
+Dmitri on Gitter: +1 agree with Sarven. tho obviously I'm a fan of DIDs, the Solid community needs to get more experience with them, etc.
 
 Justin: What constitutes maturity? If we were to compare DIDs, for example did:web and WebIDs, would there be a big maturity gap?
 
@@ -136,15 +136,15 @@ Henry: There is a reason for WebIDs: HTTP GET PUT POST DELETE using Solid protoc
 
 Aaron: 1 minute left.
 
-...: Long detour on DID protocols. The initial suggestion is not which protocol to support but do we need the door open to extend support for any kind of such identifiers in the future? Just so that how would one be able to implement this. Likewise with VCs. By boxing ourselves with webid, it's pretty narrow, by using "solid", we're very open to the future.
+...: Long detour on DID protocols. The initial suggestion is not which protocol to support, but do we need the door open to extend support for any kind of such identifiers in the future? Just how would one be able to implement this? Likewise with VCs. By boxing ourselves with WebID, it's pretty narrow; by using "Solid", we're very open to the future.
 
 From Gitter: https://gitter.im/solid/authentication-panel?at=604f75c9823b6654d2aa04a1
-Dmitri: +1 agree with Sarven. tho obviously I'm a fan of DIDs, the solid community needs to get more experience with em etc
+```
 justinweb: so i think aaron’s proposal leaves the door open without committing +1 for solid claim, +1 for IRI
 bblfish (henry): +1 for leaving the door open, but if we leave the door open, we should specify how extensions are going to work.
-matthieu: +1 to leave the door open, +1 for solid claim, +1 fo IRI
+matthieu: +1 to leave the door open, +1 for solid claim, +1 for IRI
 elf: +1 to keep it open, preferably with explicit discovery / negotiation
-
+```
 csarven: Proposed Action: Rename to solid and IRI range. Solid OIDC editors to document interop re diff IRIs
 
 Aaron: I'll open an issue on the authn panel and point people to it.


### PR DESCRIPTION
I don't understand why the "From Gitter" snippet (near the bottom) remains. The whole log appears to be a cleaned up version of such raw notes; why wasn't this part cleaned up and presented in the same way?