### PR TITLE
De-duplicate the status of this document header

### DIFF
--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -20,30 +20,28 @@ Abstract:
   access multiple potentially untrusted resources servers securely. This document aims to address that
   challenge by building on top of current and future web standards, to allow entities to authenticate
   within a Solid ecosystem.
+Status Text:
+  This section describes the status of this document at the time of its publication. Other documents
+  may supersede this document. A list of current W3C publications and the latest revision of this
+  technical report can be found in the [W3C technical reports index](https://www.w3.org/TR/) at
+  https://www.w3.org/TR/.
+
+  This document is produced from work by
+  the [Solid Community Group](https://www.w3.org/community/solid/). It is a draft document that may,
+  or may not, be officially published. It may be updated, replaced, or obsoleted by other documents at
+  any time. It is inappropriate to cite this document as anything other than work in progress. The
+  source code for this document is available at the following
+  URI: [https://github.com/solid/authentication-panel](https://github.com/solid/authentication-panel)
+
+  This document was published by the
+  [Solid Authentication Panel](https://github.com/solid/process/blob/master/panels.md#authentication)
+  as a First Draft.
+
+  [GitHub Issues](https://github.com/solid/authentication-panel/issues) are preferred for discussion
+  of this specification. Alternatively, you can send comments to our mailing list. Please send them to
+  [public-solid@w3.org](mailto:public-solid@w3.org)
+  ([archives](https://lists.w3.org/Archives/Public/public-solid/))
 </pre>
-
-<h2 class="no-num no-toc" id="status">Status of This Document</h2>
-
-This section describes the status of this document at the time of its publication. Other documents
-may supersede this document. A list of current W3C publications and the latest revision of this
-technical report can be found in the [W3C technical reports index](https://www.w3.org/TR/) at
-https://www.w3.org/TR/.
-
-This document is produced from work by
-the [Solid Community Group](https://www.w3.org/community/solid/). It is a draft document that may,
-or may not, be officially published. It may be updated, replaced, or obsoleted by other documents at
-any time. It is inappropriate to cite this document as anything other than work in progress. The
-source code for this document is available at the following
-URI: [https://github.com/solid/authentication-panel](https://github.com/solid/authentication-panel)
-
-This document was published by the
-[Solid Authentication Panel](https://github.com/solid/process/blob/master/panels.md#authentication)
-as a First Draft.
-
-[GitHub Issues](https://github.com/solid/authentication-panel/issues) are preferred for discussion
-of this specification. Alternatively, you can send comments to our mailing list. Please send them to
-[public-solid@w3.org](mailto:public-solid@w3.org)
-([archives](https://lists.w3.org/Archives/Public/public-solid/))
 
 # Introduction # {#intro}
 


### PR DESCRIPTION
Apparently, the latest version of bikeshed relies on the `Status Text` metadata header to generate the "Status of this document" section.

It results in a duplicated header on the current spec:
<img width="846" alt="Screenshot 2021-04-01 at 11 50 29" src="https://user-images.githubusercontent.com/613619/113283987-e3f8e000-92e0-11eb-85b8-94a6e25f99ea.png">

See also: https://solid.github.io/authentication-panel/solid-oidc/