### PR TITLE
Define JSON-LD context for use with client identifiers

### DIFF
--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -181,9 +181,16 @@ SHOULD use a WebID as their Client ID.
 
 ## WebID ## {#clientids-webid}
 
-The WebID itself MUST resolve to an RDF document. That document SHOULD be available as JSON-LD with an `@context`
-that includes `https://www.w3.org/ns/solid/oidc-context.jsonld` but which otherwise produces a JSON serialization of an OIDC
-client registration, per the definition of client registration metadata from [[!RFC7591]] section 2.
+A client's WebID resource MUST be serialized as an `application/ld+json` document when
+the request includes an Accept header, unless content negotiation requires a different
+outcome.
+
+The serialized JSON form of a client WebID SHOULD use the normative JSON-LD `@context`
+provided at `https://www.w3.org/ns/solid/oidc-context.jsonld` such that the resulting
+document produces a JSON serialization of an OIDC client registration, per the
+definition of client registration metadata from [[!RFC7591]] section 2.
+Client WebID documents MAY augment the normative context with additional `@context`
+definitions but MUST NOT override or change the terms defined by the normative context.
 
 Issue: [Related Issue](https://github.com/solid/authentication-panel/issues/75)
 Solid-OIDC client description in WebID document

--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -196,7 +196,7 @@ list.
 
 NOTE: the method by which the IdP resolves the WebID to an RDF document, is defined in
 [WebID 1.0](https://www.w3.org/2005/Incubator/webid/spec/identity/#processing-the-webid-profile).
-This example uses [JSON-LD  ](https://www.w3.org/TR/json-ld11/):
+This example uses [JSON-LD](https://www.w3.org/TR/json-ld11/):
 
 <div class='example'>
     <p>https://app.example/webid#id

--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -182,7 +182,7 @@ SHOULD use a WebID as their Client ID.
 ## WebID ## {#clientids-webid}
 
 The WebID itself MUST resolve to an RDF document. That document SHOULD be available as JSON-LD with an `@context`
-that includes `https://www.w3.org/ns/solid/oidc.jsonld` but which otherwise produces a JSON serialization of an OIDC
+that includes `https://www.w3.org/ns/solid/oidc-context.jsonld` but which otherwise produces a JSON serialization of an OIDC
 client registration, per the definition of client registration metadata from [[!RFC7591]] section 2.
 
 Issue: [Related Issue](https://github.com/solid/authentication-panel/issues/75)
@@ -203,7 +203,7 @@ This example uses [JSON-LD  ](https://www.w3.org/TR/json-ld11/):
 
     <pre>
         {
-          "@context": "https://www.w3.org/ns/solid/oidc.jsonld",
+          "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
 
           "client_id": "https://app.example/webid#id",
           "client_name": "Solid Application Name",

--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -223,7 +223,7 @@ This example uses [JSON-LD  ](https://www.w3.org/TR/json-ld11/):
 ### JSON-LD context
 
 This specification defines a JSON-LD context for use with OIDC client identifiers. This context is
-available at `https://www.w3.org/ns/solid/oidc.jsonld`. Client identifier documents that reference
+available at `https://www.w3.org/ns/solid/oidc-context.jsonld`. Client identifier documents that reference
 this JSON-LD context MUST use the HTTPS scheme.
 
 NOTE: the `oidc` vocabulary that is part of this context uses the HTTP scheme.

--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -181,9 +181,9 @@ SHOULD use a WebID as their Client ID.
 
 ## WebID ## {#clientids-webid}
 
-The WebID itself MUST resolve to an RDF document that MUST include a single `solid:oidcRegistration`
-property. That property MUST be a JSON serialization of an OIDC client registration, per the definition
-of client registration metadata from [[!RFC7591]] section 2.
+The WebID itself MUST resolve to an RDF document. That document SHOULD be available as JSON-LD with an `@context`
+that includes `https://www.w3.org/ns/solid/oidc.jsonld` but which otherwise produces a JSON serialization of an OIDC
+client registration, per the definition of client registration metadata from [[!RFC7591]] section 2.
 
 Issue: [Related Issue](https://github.com/solid/authentication-panel/issues/75)
 Solid-OIDC client description in WebID document
@@ -196,27 +196,108 @@ list.
 
 NOTE: the method by which the IdP resolves the WebID to an RDF document, is defined in
 [WebID 1.0](https://www.w3.org/2005/Incubator/webid/spec/identity/#processing-the-webid-profile).
-This example uses [Turtle](https://www.w3.org/TR/turtle/):
+This example uses [JSON-LD  ](https://www.w3.org/TR/json-ld11/):
 
 <div class='example'>
     <p>https://app.example/webid#id
 
     <pre>
-        @prefix solid: <http://www.w3.org/ns/solid/terms#> .
+        {
+          "@context": "https://www.w3.org/ns/solid/oidc.jsonld",
 
-        <#id> solid:oidcRegistration """{
-            "client_id" : "https://app.example/webid#id",
-            "redirect_uris" : ["https://app.example/callback"],
-            "client_name" : "Solid Application Name",
-            "client_uri" : "https://app.example/",
-            "logo_uri" : "https://app.example/logo.png",
-            "tos_uri" : "https://app.example/tos.html",
-            "scope" : "openid profile offline_access",
-            "grant_types" : ["refresh_token","authorization_code"],
-            "response_types" : ["code"],
-            "default_max_age" : 60000,
-            "require_auth_time" : true
-            }""" .
+          "client_id": "https://app.example/webid#id",
+          "client_name": "Solid Application Name",
+          "redirect_uris": ["https://app.example/callback"],
+          "client_uri": "https://app.example/",
+          "logo_uri" : "https://app.example/logo.png",
+          "tos_uri" : "https://app.example/tos.html",
+          "scope" : "openid profile offline_access",
+          "grant_types" : ["refresh_token","authorization_code"],
+          "response_types" : ["code"],
+          "default_max_age" : 3600,
+          "require_auth_time" : true
+        }
+    </pre>
+</div>
+
+### JSON-LD context
+
+This specification defines a JSON-LD context for use with OIDC client identifiers. This context is
+available at `https://www.w3.org/ns/solid/oidc.jsonld`. Client identifier documents that reference
+this JSON-LD context MUST use the HTTPS scheme.
+
+NOTE: the `oidc` vocabulary that is part of this context uses the HTTP scheme.
+
+The JSON-LD context is defined as:
+
+<div class='example'>
+    <pre>
+        {
+          "@context": {
+            "oidc": "http://www.w3.org/ns/solid/oidc#",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "client_id": {
+              "@id": "@id",
+              "@type": "@id"
+            },
+            "client_uri": {
+              "@id": "oidc:client_uri",
+              "@type": "@id"
+            },
+            "logo_uri": {
+              "@id": "oidc:logo_uri",
+              "@type": "@id"
+            },
+            "policy_uri": {
+              "@id": "oidc:policy_uri",
+              "@type": "@id"
+            },
+            "tos_uri": {
+              "@id": "oidc:tos_uri",
+              "@type": "@id"
+            },
+            "redirect_uris": {
+              "@id": "oidc:redirect_uris",
+              "@type": "@id",
+              "@container": [
+                "@id",
+                "@set"
+              ]
+            },
+            "require_auth_time": {
+              "@id": "oidc:require_auth_time",
+              "@type": "xsd:boolean"
+            },
+            "default_max_age": {
+              "@id": "oidc:default_max_age",
+              "@type": "xsd:integer"
+            },
+            "application_type": {
+              "@id": "oidc:application_type"
+            },
+            "client_name": {
+              "@id": "oidc:client_name"
+            },
+            "client_secret": {
+              "@id": "oidc:client_secret"
+            },
+            "contacts": {
+              "@id": "oidc:contacts"
+            },
+            "grant_types": {
+              "@id": "oidc:grant_types"
+            },
+            "response_types": {
+              "@id": "oidc:response_types"
+            },
+            "scope": {
+              "@id": "oidc:scope"
+            },
+            "token_endpoint_auth_method": {
+              "@id": "oidc:token_endpoint_auth_method"
+            }
+          }
+        }
     </pre>
 </div>
 

--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -196,7 +196,7 @@ list.
 
 NOTE: the method by which the IdP resolves the WebID to an RDF document, is defined in
 [WebID 1.0](https://www.w3.org/2005/Incubator/webid/spec/identity/#processing-the-webid-profile).
-This example uses [JSON-LD](https://www.w3.org/TR/json-ld11/):
+This example uses [JSON-LD ](https://www.w3.org/TR/json-ld11/):
 
 <div class='example'>
     <p>https://app.example/webid#id
@@ -220,7 +220,7 @@ This example uses [JSON-LD](https://www.w3.org/TR/json-ld11/):
     </pre>
 </div>
 
-### JSON-LD context
+### JSON-LD context # {#jsonld-context}
 
 This specification defines a JSON-LD context for use with OIDC client identifiers. This context is
 available at `https://www.w3.org/ns/solid/oidc-context.jsonld`. Client identifier documents that reference

--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -182,7 +182,7 @@ SHOULD use a WebID as their Client ID.
 ## WebID ## {#clientids-webid}
 
 A client's WebID resource MUST be serialized as an `application/ld+json` document when
-the request includes an Accept header, unless content negotiation requires a different
+the request includes an `Accept` header, unless content negotiation requires a different
 outcome.
 
 The serialized JSON form of a client WebID SHOULD use the normative JSON-LD `@context`

--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -189,8 +189,6 @@ The serialized JSON form of a client WebID SHOULD use the normative JSON-LD `@co
 provided at `https://www.w3.org/ns/solid/oidc-context.jsonld` such that the resulting
 document produces a JSON serialization of an OIDC client registration, per the
 definition of client registration metadata from [[!RFC7591]] section 2.
-Client WebID documents MAY augment the normative context with additional `@context`
-definitions but MUST NOT override or change the terms defined by the normative context.
 
 Issue: [Related Issue](https://github.com/solid/authentication-panel/issues/75)
 Solid-OIDC client description in WebID document
@@ -241,6 +239,8 @@ The JSON-LD context is defined as:
     <pre>
         {
           "@context": {
+            "@version": "1.1",
+            "@protected": true,
             "oidc": "http://www.w3.org/ns/solid/oidc#",
             "xsd": "http://www.w3.org/2001/XMLSchema#",
             "client_id": {

--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -181,9 +181,8 @@ SHOULD use a WebID as their Client ID.
 
 ## WebID ## {#clientids-webid}
 
-A client's WebID resource MUST be serialized as an `application/ld+json` document when
-the request includes an `Accept` header, unless content negotiation requires a different
-outcome.
+A client's WebID resource MUST be serialized as an `application/ld+json` document
+unless content negotiation requires a different outcome.
 
 The serialized JSON form of a client WebID SHOULD use the normative JSON-LD `@context`
 provided at `https://www.w3.org/ns/solid/oidc-context.jsonld` such that the resulting


### PR DESCRIPTION
Resolves #75

As discussed on [3/29/21](https://github.com/solid/authentication-panel/blob/main/meetings/2021-03-29.md#define-solid-oidc-issue), this changes the client identifier definition from being a JSON literal to being a first-class RDF-based serialization. This also defines a JSON-LD `@context` that can be used to bridge the RDF world of Solid and the JSON world of OIDC.

Open questions:

1. This proposal suggests publishing the JSON-LD context file at `https://www.w3.org/ns/solid/oidc.jsonld`. I do not have any real opinion about that URL, other than that it should use HTTPS and use a `.jsonld` extension. Should it instead be published under `https://solidproject.org/TR/...`?

2. This PR also refers to an `oidc` vocabulary which does not currently exist. That vocabulary (once published) would simply define URLs for the various OIDC-related field names. As with the URL for the JSON-LD `@context`, should this be published under `https://www.w3.org/ns/...` or under `https://solidproject.org/TR/...`?