### PR TITLE
Fix heading format

### DIFF
--- a/proposals/solid-oidc/index.bs
+++ b/proposals/solid-oidc/index.bs
@@ -224,7 +224,7 @@ This example uses [JSON-LD ](https://www.w3.org/TR/json-ld11/):
     </pre>
 </div>
 
-### JSON-LD context ## {#jsonld-context}
+### JSON-LD context ### {#jsonld-context}
 
 This specification defines a JSON-LD context for use with OIDC client identifiers. This context is
 available at `https://www.w3.org/ns/solid/oidc-context.jsonld`. Client identifier documents that reference


### PR DESCRIPTION
Section 5.1.1 currently has a formatting error with the heading:

![image](https://user-images.githubusercontent.com/1265883/122104349-953deb00-cde5-11eb-8c8c-e4b5fc1411d9.png)

This change will result in the following:

![image](https://user-images.githubusercontent.com/1265883/122104429-a686f780-cde5-11eb-981d-fa6a18fd77a7.png)
