### PR TITLE
Add reference to the Solid Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Areas of interest:
 For contributing members see the
 [Panels List](https://github.com/solid/process/blob/master/panels.md#authentication-panel).
 
+The Solid Authentication Panel meetings and associated communication channels are open to all
+to participate. It is expected that everyone will abide by the
+[Solid Code of Conduct](https://github.com/solid/process/blob/main/code-of-conduct.md)
+in all of these interactions.
+
 ## Projects
 
 [Submit an issue](https://github.com/solid/authentication-panel/issues/new)


### PR DESCRIPTION
This adds a reference to the Solid Code of Conduct in the authentication panel README