### PR TITLE
Make note of cancelled meeting

### DIFF
--- a/meetings/2021-09-20.md
+++ b/meetings/2021-09-20.md
@@ -1,0 +1,6 @@
+# 2021-09-20 Solid Authentication
+
+https://meet.jit.si/solid-authentication
+
+**Note**: the authentication panel meeting was cancelled and did not take place on this date.
+


### PR DESCRIPTION
The Sept 20 meeting was cancelled due to lack of attendance. For anyone browsing the historical meeting minutes, this just states that the meeting didn't happen (as opposed to there being no notes).