### PR TITLE
Use UTC in meeting timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ The Solid-OIDC specification documents are available in the [solid/solid-oidc](h
 
 ## Meetings
 
-Meetings of the Authentication panel take place at 10AM eastern on Mondays. 
+Meetings of the Authentication panel take place at 1400 UTC on Mondays.
 
 Meeting link: https://meet.jit.si/solid-authentication


### PR DESCRIPTION
In order to avoid timezone confusion, this switches the README to use UTC